### PR TITLE
Fix the TenantID for AppLens

### DIFF
--- a/pkg/frontend/adminactions/azureactions.go
+++ b/pkg/frontend/adminactions/azureactions.go
@@ -61,7 +61,7 @@ func NewAzureActions(log *logrus.Entry, env env.Interface, oc *api.OpenShiftClus
 		return nil, err
 	}
 
-	fpClientCertCred, err := env.FPNewClientCertificateCredential(subscriptionDoc.Subscription.Properties.TenantID)
+	fpClientCertCred, err := env.FPNewClientCertificateCredential(env.Environment().AppLensTenantID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/azureclient/environments.go
+++ b/pkg/util/azureclient/environments.go
@@ -19,6 +19,7 @@ type AROEnvironment struct {
 	AppSuffix                string
 	AppLensEndpoint          string
 	AppLensScope             string
+	AppLensTenantID          string
 	azidentity.AuthorityHost
 }
 
@@ -31,17 +32,20 @@ var (
 		AppSuffix:                "aro.azure.com",
 		AppLensEndpoint:          "https://diag-runtimehost-prod.trafficmanager.net/api/invoke",
 		AppLensScope:             "b9a1efcd-32ee-4330-834c-c04eb00f4b33",
+		AppLensTenantID:          "72f988bf-86f1-41af-91ab-2d7cd011db47",
 		AuthorityHost:            azidentity.AzurePublicCloud,
 	}
 
 	// USGovernmentCloud contains additional ARO information for the US Gov cloud environment.
 	USGovernmentCloud = AROEnvironment{
-		Environment:              azure.USGovernmentCloud,
+		Environment: azure.USGovernmentCloud,
+
 		ActualCloudName:          "AzureUSGovernment",
 		GenevaMonitoringEndpoint: "https://gcs.monitoring.core.usgovcloudapi.net/",
 		AppSuffix:                "aro.azure.us",
 		AppLensEndpoint:          "https://diag-runtimehost-prod-bn1-001.azurewebsites.us/api/invoke",
 		AppLensScope:             "https://microsoft.onmicrosoft.com/runtimehost",
+		AppLensTenantID:          "cab8a31a-1906-4287-a0d8-4eef66b95f6e",
 		AuthorityHost:            azidentity.AzureGovernment,
 	}
 )

--- a/pkg/util/azureclient/environments.go
+++ b/pkg/util/azureclient/environments.go
@@ -38,8 +38,7 @@ var (
 
 	// USGovernmentCloud contains additional ARO information for the US Gov cloud environment.
 	USGovernmentCloud = AROEnvironment{
-		Environment: azure.USGovernmentCloud,
-
+		Environment:              azure.USGovernmentCloud,
 		ActualCloudName:          "AzureUSGovernment",
 		GenevaMonitoringEndpoint: "https://gcs.monitoring.core.usgovcloudapi.net/",
 		AppSuffix:                "aro.azure.us",


### PR DESCRIPTION
Use AppLens TenantID instead of customer's tenant ID.